### PR TITLE
Avoid Docker and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,47 @@
 # GetMoarFediverse-action
+
+This action runs [GetMoarFediverse](https://github.com/g3rv4/GetMoarFediverse) as a GitHub action, which means... you don't need to host it anywhere!
+
+## How to use it
+
+There's a video [here](https://youtu.be/fyOSAzqpcQM), demoing all the steps needed for it to work. There's also a demo repo [here](https://github.com/g3rv4/GMFActionDemo).
+
+1. Build a `config.json` as specified on the [GetMoarFediverse README](https://github.com/g3rv4/GetMoarFediverse/blob/main/README.md) and put it on your repo. Don't include `FakeRelayApiKey` on the json file.
+
+It could be something like this:
+
+```
+{
+    "FakeRelayUrl": "https://fakerelay.gervas.io",
+    "Tags": [ "dotnet", "csharp" ],
+    "Instances": [ "hachyderm.io", "mastodon.social" ]
+}
+```
+
+One important thing is that you **do not** include the `FakeRelayApi`, as that would be visible by anyone.
+
+2. Add a GitHub secret to your repository named `FAKERELAY_APIKEY` with the api key for the FakeRelay instance set up on `config.json`
+3. Add a file named `.github/workflows/GetMoarFediverse.yml` with this content:
+
+```
+name: GetMoarFediverse
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+jobs:
+  moar:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: chdorner/GetMoarFediverse-action@main
+        with:
+          config_file: ${{ github.workspace }}/config.json
+          api_key: ${{ secrets.FAKERELAY_APIKEY }}
+```
+
+This will execute the action every 15 minutes automatically.
+
+And that's it!

--- a/action.yml
+++ b/action.yml
@@ -6,10 +6,10 @@ inputs:
     required: true
   api_key:
     description: FakeRelay API key if it isn't defined in the config.json
-  tag:
-    description: Tag of the getmoarfediverse docker container
+  executable_path:
+    description: Path to the GetMoarFediverse archive
     required: true
-    default: latest
+    default: https://github.com/g3rv4/getMoarFediverse/releases/latest/download/GetMoarFediverse_linux-x64.tgz
 runs:
   using: composite
   steps:
@@ -30,7 +30,7 @@ runs:
       env:
         FAKERELAY_APIKEY: ${{ inputs.api_key }}
       run: |
-        wget -nv https://github.com/g3rv4/getMoarFediverse/releases/latest/download/GetMoarFediverse_linux-x64.tgz
+        wget -nv ${{ inputs.executable_path }}
         tar -xzf GetMoarFediverse_linux-x64.tgz
         cd GetMoarFediverse-*
         ./GetMoarFediverse ${{ env.MOAR_TMP_DIR }}/config.json

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,11 @@ runs:
     - name: import-data
       env:
         FAKERELAY_APIKEY: ${{ inputs.api_key }}
-      run: docker run -v "${MOAR_TMP_DIR}:/data" -e "FAKERELAY_APIKEY=${FAKERELAY_APIKEY}" ghcr.io/g3rv4/getmoarfediverse:${{ inputs.tag }}
+      run: |
+        wget -nv https://github.com/g3rv4/getMoarFediverse/releases/latest/download/GetMoarFediverse_linux-x64.tgz
+        tar -xzf GetMoarFediverse_linux-x64.tgz
+        cd GetMoarFediverse-*
+        ./GetMoarFediverse ${{ env.MOAR_TMP_DIR }}/config.json
       shell: bash
     - name: store artifact
       uses: actions/upload-artifact@v3

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
   executable_path:
     description: Path to the GetMoarFediverse archive
     required: true
-    default: https://github.com/g3rv4/getMoarFediverse/releases/latest/download/GetMoarFediverse_linux-x64.tgz
+    default: https://github.com/g3rv4/GetMoarFediverse/releases/latest/download/GetMoarFediverse_linux-x64.tgz
 runs:
   using: composite
   steps:


### PR DESCRIPTION
I'm making two changes here:

* Avoiding docker... now that I'm building executables, it's way faster than using docker
* Update the README file. I recorded a video showing how to use it :)